### PR TITLE
Add a query logfile

### DIFF
--- a/bin/add.cxx
+++ b/bin/add.cxx
@@ -117,7 +117,7 @@ int main(int argc, char **argv)
     {
         for (auto& v : db->listVideos())
         {
-            std::cout << std::endl << "Recalculating Scenes for " << v;
+            std::cout << "Recalculating Scenes for " << v << std::endl;
             auto video = db->loadVideo(v);
             db->saveVideo(*video);
         }

--- a/bin/query.cxx
+++ b/bin/query.cxx
@@ -41,103 +41,33 @@ int main(int argc, char **argv)
     auto &fd = *query_database_factory(argv[DBPATH], -1, -1, -1).release();
     auto video2 = make_query_adapter(video, fd);
 
-    std::optional<MatchInfo> match;
+    std::vector<MatchInfo> matches;
 
     if(argc == 4) {
-        match = findMatch(video.frames(), fd);
+        matches = findMatch(video.frames(), fd);
     } else if(argc == 3) {
-        match = findMatch(video2, fd);
+        matches = findMatch(video2, fd);
     }
 
     std::string bestmatch = "";
-    if (match)
+
+    if(matches.size() > 0) {
+        bestmatch = matches[0].video;
+    }
+
+    int count = 0;
+
+    for(auto a: matches)
     {
-        bestmatch = match->video;
-        std::cout << std::endl
-                  << "confidence: " << match->matchConfidence << " video: " << match->video << std::endl
-                  << std::endl;
-        int count = 0;
-        for (auto a : match->alignments)
-        {
-            if (a.score > (match->matchConfidence / 2.5))
-            {
-                count++;
-                std::cout << "Alignment " << count << ", Score: " << a.score << std::endl;
-                std::cout << "Scene range in " << match->video << ": [" << a.startKnown << ", " << a.endKnown << ")" << std::endl;
-                std::cout << "Scene range in " << video2.name << ": [" << a.startUnknown << ", " << a.endUnknown << ")" << std::endl
-                          << std::endl;
-            }
-        }
+        count++;
+        std::cout << "Alignment " << count << ", Score: " << a.confidence << std::endl;
+        std::cout << "Frame range in " << a.video << ": [" << a.startKnown << ", " << a.endKnown << ")" << std::endl;
+        std::cout << "Frame range in " << video2.name << ": [" << a.startQuery << ", " << a.endQuery << ")" << std::endl
+                    << std::endl;
     }
 
     f << bestmatch;
     f.close();
-
-    // namedWindow("Display window", WINDOW_NORMAL );// Create a window for display.
-    //
-    // auto myvocab = loadVocabulary<Vocab<IScene>>(fd)->descriptors();
-    // auto myframevocab = loadVocabulary<Frame>(fd)->descriptors();
-    //
-    // auto videopaths = fd.loadVideo();
-    // bool first = 1;
-    // Frame firstFrame;
-    //
-    // auto mycomp = BOWComparator(myvocab);
-    //
-    // // for each video, compare first frame to rest of frames
-    // /*for(auto videopath : videopaths){
-    //
-    //     auto video = fd.loadVideo(videopath);
-    //     auto frames = video->frames();
-    //     for(auto& frame : frames){
-    //         if(first){
-    //             first = 0;
-    //             firstFrame = frame;
-    //             std::cout << frameSimilarity(firstFrame, firstFrame, myvocab) << std::endl;
-    //             continue;
-    //         }
-    //         else{
-    //             std::cout << frameSimilarity(firstFrame, frame, myvocab) << std::endl;
-    //         }
-    //
-    //         //Mat mymat = baggify(frame, myvocab);
-    //     }
-    // }*/
-    //
-    // auto intcomp = [](auto& b1, auto& b2) {
-    //     auto a = cosineSimilarity(b1, b2);
-    //     return a > 0.8 ? 3 : -3;
-    // };
-    //
-    // // similarity between each two videos
-    // for(int i = 0; i < videopaths.size() - 1; i++){
-    //     auto& v1 = videopaths[i];
-    //
-    //     auto fb1 = flatScenesBags(*v1, mycomp, 0.2, myframevocab);
-    //
-    //     VideoMatchingInstrumenter instrumenter(*v1);
-    //     auto reporter = getReporter(instrumenter);
-    //     for(int j = i + 1; j < videopaths.size(); j++){
-    //         auto& v2 = videopaths[j];
-    //         std::cout << "Comparing " << v1->name << " to " << v2->name << std::endl;
-    //
-    //         std::cout << "Boneheaded Similarity: " << boneheadedSimilarity(*v1, *v2, mycomp, reporter) << std::endl << std::endl;
-    //
-    //         auto fb2 = flatScenesBags(*v2, mycomp, 0.2, myframevocab);
-    //
-    //         std::cout << "fb1 size: " << fb1.size() << " fb2: " << fb2.size() << std::endl;
-    //         auto&& alignments = calculateAlignment(fb1, fb2, intcomp, 0, 2);
-    //
-    //         std::cout << "Scene sw: " << std::endl;
-    //         for(auto& al : alignments){
-    //             std::cout << static_cast<std::string>(al) << std::endl;
-    //         }
-    //
-    //
-    //     }
-    //
-    //     EmmaExporter().exportTimeseries(v1->name, "frame no.", "cosine distance", instrumenter.getTimeSeries());
-    // }
 
     return 0;
 }

--- a/bin/query.cxx
+++ b/bin/query.cxx
@@ -77,10 +77,10 @@ int main(int argc, char **argv)
             match.video,
             match.confidence,
             match.knownFrameRate,
-            static_cast<size_t>(match.startQuery / queryFrameRate),
-            static_cast<size_t>(match.endQuery / queryFrameRate),
-            static_cast<size_t>(match.startKnown / match.knownFrameRate),
-            static_cast<size_t>(match.endKnown / match.knownFrameRate)
+            static_cast<size_t>(match.startQuery / queryFrameRate * 1000.0),
+            static_cast<size_t>(match.endQuery / queryFrameRate * 1000.0),
+            static_cast<size_t>(match.startKnown / match.knownFrameRate * 1000.0),
+            static_cast<size_t>(match.endKnown / match.knownFrameRate * 1000.0)
         };
     });
 

--- a/bin/query.cxx
+++ b/bin/query.cxx
@@ -69,5 +69,22 @@ int main(int argc, char **argv)
     f << bestmatch;
     f.close();
 
+    double queryFrameRate = video.getProperties().frameRate;
+
+    std::vector<MatchInfo> timestampMatches(matches.size());
+    std::transform(matches.begin(), matches.end(), timestampMatches.begin(), [queryFrameRate](auto match){
+        return MatchInfo{
+            match.video,
+            match.confidence,
+            match.knownFrameRate,
+            static_cast<size_t>(match.startQuery / queryFrameRate),
+            static_cast<size_t>(match.endQuery / queryFrameRate),
+            static_cast<size_t>(match.startKnown / match.knownFrameRate),
+            static_cast<size_t>(match.endKnown / match.knownFrameRate)
+        };
+    });
+
+    CSVExporter{"./results"}.exportMatchLogs(video.name + ".csv", timestampMatches);
+
     return 0;
 }

--- a/include/database.hpp
+++ b/include/database.hpp
@@ -44,10 +44,11 @@ struct DatabaseMetadata {
     }
 };
 
-struct VideoMetadata : public DatabaseMetadata {
-    size_t frameCount;
+struct VideoMetadata : public DatabaseMetadata, public InputVideoProperties {
     size_t sceneCount;
-    float frameRate;
+
+    VideoMetadata() = default;
+    VideoMetadata(const InputVideoProperties& other): DatabaseMetadata(), InputVideoProperties(other), sceneCount(0) {}
 };
 
 

--- a/include/database.hpp
+++ b/include/database.hpp
@@ -47,6 +47,7 @@ struct DatabaseMetadata {
 struct VideoMetadata : public DatabaseMetadata {
     size_t frameCount;
     size_t sceneCount;
+    float frameRate;
 };
 
 

--- a/include/instrumentation.hpp
+++ b/include/instrumentation.hpp
@@ -11,6 +11,14 @@
 
 namespace fs = std::filesystem;
 
+struct MatchInfo
+{
+    std::string video;
+    double confidence;
+    double knownFrameRate;
+    size_t startQuery, endQuery, startKnown, endKnown;
+};
+
 struct FrameSimilarityInfo
 {
     double similarity;
@@ -63,7 +71,7 @@ public:
 class CSVExporter : public FSExporter
 {
     template<typename It>
-    void writeRow(std::ostream& output, It begin, It end) {
+    void writeRow(std::ostream& output, It begin, It end) const {
         if(begin != end) {
             output << *begin;
         }
@@ -75,7 +83,7 @@ class CSVExporter : public FSExporter
         output << std::endl;
     }
     template<typename It>
-    void writeCSVToDir(const std::string& filename, const std::vector<std::string>& headers, It start, It end) {
+    void writeCSVToDir(const std::string& filename, const std::vector<std::string>& headers, It start, It end) const {
         std::ofstream output(outputDir / filename);
 
         auto n_cols = headers.size();
@@ -89,8 +97,9 @@ class CSVExporter : public FSExporter
         }
     }
 public:
+    using FSExporter::FSExporter;
     const std::string delimiter = ",";
-    void exportMatchLogs();
+    void exportMatchLogs(const std::string& filename, const std::vector<MatchInfo>&) const;
 };
 
 class EmmaExporter : public FSExporter

--- a/include/instrumentation.hpp
+++ b/include/instrumentation.hpp
@@ -6,7 +6,8 @@
 #include <optional>
 #include "database_iface.hpp"
 #include "fs_compat.hpp"
-#include <functional>
+#include <fstream>
+#include <unordered_map>
 
 namespace fs = std::filesystem;
 
@@ -19,7 +20,6 @@ struct FrameSimilarityInfo
 };
 
 typedef std::string Label;
-typedef std::function<void(FrameSimilarityInfo)> SimilarityReporter;
 
 struct Point2f
 {
@@ -38,45 +38,20 @@ public:
     virtual void exportTimeseries(const Label &title, const Label &xaxis, const Label &yaxis, const std::vector<TimeSeries> &data) const = 0;
 };
 
-template <class Video>
 class VideoMatchingInstrumenter
 {
 private:
-    const Video &target;
+    IVideo target;
     std::unordered_map<std::string, std::vector<Point2f>> videoTracker;
 
 public:
-    VideoMatchingInstrumenter(const Video &targetVideo) : target(targetVideo) {}
+    VideoMatchingInstrumenter(const IVideo &targetVideo) : target(targetVideo) {}
     void clear();
-    void addFrameSimilarity(FrameSimilarityInfo info)
-    {
-        if (info.v1 && info.v2)
-        {
-            auto& known = (info.v1->name == target.name) ? *info.v2 : *info.v1;
-            videoTracker[known.name].push_back({info.f1Idx, info.similarity});
-        }
-    }
-    std::vector<TimeSeries> getTimeSeries() const
-    {
-        std::vector<TimeSeries> out;
-        for (auto &[name, points] : videoTracker)
-        {
-            std::vector<Point2f> dataCopy(points);
-            std::sort(dataCopy.begin(), dataCopy.end(), [](auto p1, auto p2) { return p1.x < p2.x; });
-            out.push_back({name, dataCopy});
-        }
-
-        return out;
-    }
+    void addFrameSimilarity(const FrameSimilarityInfo& info);
+    std::vector<TimeSeries> getTimeSeries() const;
 };
 
-template <class Video>
-SimilarityReporter getReporter(VideoMatchingInstrumenter<Video> &instrumenter)
-{
-    return [&instrumenter](auto f) { instrumenter.addFrameSimilarity(f); };
-}
-
-class FSExporter : public IExporter
+class FSExporter
 {
 protected:
     const fs::path outputDir;
@@ -87,15 +62,41 @@ public:
 
 class CSVExporter : public FSExporter
 {
+    template<typename It>
+    void writeRow(std::ostream& output, It begin, It end) {
+        if(begin != end) {
+            output << *begin;
+        }
+
+        for(auto i = begin + 1; i != end; i++) {
+            output << "," << *i;
+        }
+
+        output << std::endl;
+    }
+    template<typename It>
+    void writeCSVToDir(const std::string& filename, const std::vector<std::string>& headers, It start, It end) {
+        std::ofstream output(outputDir / filename);
+
+        auto n_cols = headers.size();
+        writeRow(output, headers.begin(), headers.end());
+
+        auto current = start;
+        while(current != end) {
+            auto row_end = current + n_cols;
+            writeRow(output, current, row_end);
+            current = row_end;
+        }
+    }
 public:
     const std::string delimiter = ",";
-    void exportTimeseries(const Label &title, const Label &xaxis, const Label &yaxis, const std::vector<TimeSeries> &data) const override;
+    void exportMatchLogs();
 };
 
 class EmmaExporter : public FSExporter
 {
 public:
-    void exportTimeseries(const Label &title, const Label &xaxis, const Label &yaxis, const std::vector<TimeSeries> &data) const override;
+    void exportTimeseries(const Label &title, const Label &xaxis, const Label &yaxis, const std::vector<TimeSeries> &data) const;
 };
 
 #endif

--- a/include/matcher.hpp
+++ b/include/matcher.hpp
@@ -3,31 +3,13 @@
 
 #include "instrumentation.hpp"
 #include "database_iface.hpp"
-#include <optional>
-
-template <typename It>
-struct ItAlignment
-{
-    It startKnown, startUnknown, endKnown, endUnknown;
-    unsigned int score;
-
-    template <typename = std::void_t<std::is_integral<It>>>
-    operator std::string()
-    {
-        return std::to_string(startKnown) + " " + std::to_string(endKnown) +
-               " " + std::to_string(startUnknown) + " " + std::to_string(endUnknown) + " " +
-               std::to_string(score);
-    }
-};
-
-typedef ItAlignment<unsigned int> Alignment;
+#include <vector>
 
 struct MatchInfo
 {
-    double matchConfidence;
-    IVideo::size_type startFrame, endFrame;
     std::string video;
-    std::vector<Alignment> alignments;
+    double confidence;
+    IVideo::size_type startQuery, endQuery, startKnown, endKnown;
 };
 
 template <typename Matrix>
@@ -88,9 +70,9 @@ class SIFTVideo;
 QueryVideo make_query_adapter(const SIFTVideo&, const FileDatabase&);
 QueryVideo make_query_adapter(const DatabaseVideo&);
 
-std::optional<MatchInfo> findMatch(QueryVideo& target, const FileDatabase &db);
-std::optional<MatchInfo> findMatch(QueryVideo&& target, const FileDatabase &db);
-std::optional<MatchInfo> findMatch(std::unique_ptr<ICursor<Frame>>, const FileDatabase &db);
-std::optional<MatchInfo> findMatch(std::unique_ptr<ICursor<SerializableScene>>, const FileDatabase &db);
+std::vector<MatchInfo> findMatch(QueryVideo& target, const FileDatabase &db);
+std::vector<MatchInfo> findMatch(QueryVideo&& target, const FileDatabase &db);
+std::vector<MatchInfo> findMatch(std::unique_ptr<ICursor<Frame>>, const FileDatabase &db);
+std::vector<MatchInfo> findMatch(std::unique_ptr<ICursor<SerializableScene>>, const FileDatabase &db);
 
 #endif

--- a/include/matcher.hpp
+++ b/include/matcher.hpp
@@ -5,13 +5,6 @@
 #include "database_iface.hpp"
 #include <vector>
 
-struct MatchInfo
-{
-    std::string video;
-    double confidence;
-    IVideo::size_type startQuery, endQuery, startKnown, endKnown;
-};
-
 template <typename Matrix>
 double cosineSimilarity(Matrix &&b1, Matrix &&b2)
 {

--- a/include/sw.hpp
+++ b/include/sw.hpp
@@ -5,7 +5,7 @@
 #include <utility>
 #include <iostream>
 #include "matrix.hpp"
-#include "matcher.hpp"
+#include <algorithm>
 #include <iostream>
 #include <atomic>
 #include <tbb/parallel_do.h>
@@ -15,6 +15,23 @@
 
 typedef VectorMatrix<uint8_t> SourceMatrix;
 typedef VectorMatrix<int_fast32_t> ScoreMatrix;
+
+template <typename It>
+struct ItAlignment
+{
+    It startKnown, startUnknown, endKnown, endUnknown;
+    unsigned int score;
+
+    template <typename = std::void_t<std::is_integral<It>>>
+    operator std::string()
+    {
+        return std::to_string(startKnown) + " " + std::to_string(endKnown) +
+               " " + std::to_string(startUnknown) + " " + std::to_string(endUnknown) + " " +
+               std::to_string(score);
+    }
+};
+
+typedef ItAlignment<unsigned int> Alignment;
 
 template <typename It>
 std::vector<ItAlignment<It>> findAlignments(It known, It unknown, ScoreMatrix &matrix, const SourceMatrix &sources, unsigned int maxAlignments)

--- a/include/video.hpp
+++ b/include/video.hpp
@@ -33,6 +33,11 @@ inline bool matEqual(const cv::Mat &a, const cv::Mat &b)
 struct Frame;
 struct SerializableScene;
 
+struct InputVideoProperties {
+    size_t frameCount;
+    float frameRate;
+};
+
 struct SIFTVideo : public IVideo
 {
     std::string filename;
@@ -45,6 +50,8 @@ struct SIFTVideo : public IVideo
     std::unique_ptr<ICursor<Frame>> frames(const Vocab<Frame>&) const;
     std::unique_ptr<ICursor<cv::UMat>> images() const;
     std::unique_ptr<ICursor<cv::Mat>> color() const;
+
+    InputVideoProperties getProperties() const;
 };
 
 struct Frame

--- a/src/database.cpp
+++ b/src/database.cpp
@@ -154,7 +154,7 @@ public:
     {
         if(min_scenes != -1) {
             scenes = hierarchicalScenes(get_distances(reader, ColorComparator2D{}), min_scenes);
-            std::cout << "Detected Scenes: " << scenes.size() << std::endl;
+            std::cout << std::endl << "Detected Scenes: " << scenes.size() << std::endl;
         }
         iterator = scenes.begin();
     }
@@ -646,6 +646,8 @@ QueryVideo make_query_adapter(const SIFTVideo &video, const FileDatabase &db)
     scene_bag_adapter adapter{
         scene_detect_cursor{*video.color(), static_cast<int>(threshold)},
         frame_bag_adapter{video.frames(), *frame_vocab}, *scene_vocab};
+
+    std::cout << std::endl;
 
     return QueryVideo{video, std::make_unique<decltype(adapter)>(std::move(adapter))};
 }

--- a/src/database.cpp
+++ b/src/database.cpp
@@ -79,14 +79,14 @@ class scene_bag_adapter : public ICursor<SerializableScene>
     SceneRead scene_reader;
     FrameRead frame_reader;
 
-    Vocab<SerializableScene> vocab;
+    BOWExtractor extractor;
     size_t f_index = 0;
 
 public:
-    scene_bag_adapter(SceneRead &&s, FrameRead &&f, const Vocab<SerializableScene> &v) : scene_reader(std::move(s)), frame_reader(std::move(f)), vocab(v) {}
-    scene_bag_adapter(SceneRead &s, FrameRead &f, const Vocab<SerializableScene> &v) : scene_reader(s), frame_reader(f), vocab(v) {}
-    scene_bag_adapter(SceneRead &s, FrameRead &&f, const Vocab<SerializableScene> &v) : scene_reader(s), frame_reader(std::move(f)), vocab(v) {}
-    scene_bag_adapter(SceneRead &&s, FrameRead &f, const Vocab<SerializableScene> &v) : scene_reader(std::move(s)), frame_reader(f), vocab(v) {}
+    scene_bag_adapter(SceneRead &&s, FrameRead &&f, const Vocab<SerializableScene> &v) : scene_reader(std::move(s)), frame_reader(std::move(f)), extractor(v) {}
+    scene_bag_adapter(SceneRead &s, FrameRead &f, const Vocab<SerializableScene> &v) : scene_reader(s), frame_reader(f), extractor(v) {}
+    scene_bag_adapter(SceneRead &s, FrameRead &&f, const Vocab<SerializableScene> &v) : scene_reader(s), frame_reader(std::move(f)), extractor(v) {}
+    scene_bag_adapter(SceneRead &&s, FrameRead &f, const Vocab<SerializableScene> &v) : scene_reader(std::move(s)), frame_reader(f), extractor(v) {}
 
     void skip(unsigned int n) override {
         if constexpr(has_arrow_v<SceneRead>) {
@@ -135,7 +135,7 @@ public:
             }
 
             // std::cout << "bagging scene of length: " << frames.size() << std::endl;
-            val->frameBag = baggify(frames.begin(), frames.end(), BOWExtractor{vocab});
+            val->frameBag = baggify(frames.begin(), frames.end(), extractor);
             return val;
         }
         return std::nullopt;

--- a/src/instrumentation.cpp
+++ b/src/instrumentation.cpp
@@ -40,3 +40,18 @@ std::vector<TimeSeries> VideoMatchingInstrumenter::getTimeSeries() const
 
     return out;
 }
+
+void CSVExporter::exportMatchLogs(const std::string& filename, const std::vector<MatchInfo>& matches) const {
+    std::vector<std::string> headers = {"Database Video", "Confidence", "Start Time", "End Time", "Query Start Time", "Query End Time"};
+    std::vector<std::string> cells;
+    for(const MatchInfo& match: matches) {
+        cells.emplace_back(match.video);
+        cells.emplace_back(std::to_string(match.confidence));
+        cells.emplace_back(std::to_string(match.startKnown));
+        cells.emplace_back(std::to_string(match.endKnown));
+        cells.emplace_back(std::to_string(match.startQuery));
+        cells.emplace_back(std::to_string(match.endQuery));
+    }
+
+    writeCSVToDir(filename, headers, cells.begin(), cells.end());
+}

--- a/src/instrumentation.cpp
+++ b/src/instrumentation.cpp
@@ -1,6 +1,7 @@
 #include "instrumentation.hpp"
 #include "fs_compat.hpp"
 #include <fstream>
+#include <algorithm>
 
 void EmmaExporter::exportTimeseries(const Label &title, const Label &xaxis, const Label &yaxis, const std::vector<TimeSeries> &data) const
 {
@@ -16,4 +17,26 @@ void EmmaExporter::exportTimeseries(const Label &title, const Label &xaxis, cons
             out << point.y << std::endl;
         }
     }
+}
+
+void VideoMatchingInstrumenter::addFrameSimilarity(const FrameSimilarityInfo& info)
+{
+    if (info.v1 && info.v2)
+    {
+        auto& known = (info.v1->name == target.name) ? *info.v2 : *info.v1;
+        videoTracker[known.name].push_back({static_cast<float>(info.f1Idx), static_cast<float>(info.similarity)});
+    }
+}
+
+std::vector<TimeSeries> VideoMatchingInstrumenter::getTimeSeries() const
+{
+    std::vector<TimeSeries> out;
+    for (auto &[name, points] : videoTracker)
+    {
+        std::vector<Point2f> dataCopy(points);
+        std::sort(dataCopy.begin(), dataCopy.end(), [](auto p1, auto p2) { return p1.x < p2.x; });
+        out.push_back({name, dataCopy});
+    }
+
+    return out;
 }

--- a/src/matcher.cpp
+++ b/src/matcher.cpp
@@ -241,10 +241,10 @@ Vocab<SerializableScene> constructSceneVocabularyHierarchical(const FileDatabase
 			if(descriptor_levels[0].rows >= N){
 				overflow(descriptor_levels, K, N, 0);
 			}
+
+            frames ->skip(speedinator);
 		}
     }
-
-    return Vocab<SerializableScene>(constructVocabulary(descriptor_levels.begin(), descriptor_levels.end(), K));
 
     // flush all remaining features to lowest level
     for (int i = 0; i < descriptor_levels.size(); i++)

--- a/src/matcher.cpp
+++ b/src/matcher.cpp
@@ -291,28 +291,28 @@ std::optional<MatchInfo> internal_findMatch(Reader&& reader, const FileDatabase 
     auto intcomp = [](auto f1, auto f2) { return cosineSimilarity(f1, f2) > 0.8 ? 3 : -3; };
 
     MatchInfo match{};
-    std::vector<cv::Mat> targetScenes;
+    std::vector<cv::Mat> targetDescriptors;
 
     if constexpr(std::is_same_v<value_type, SerializableScene>)
-        while(auto scene = reader.read()) targetScenes.push_back(scene->frameBag);
+        while(auto scene = reader.read()) targetDescriptors.push_back(scene->frameBag);
     else if constexpr(std::is_same_v<value_type, Frame>)
-        while(auto frame = reader.read()) targetScenes.push_back(frame->frameDescriptor);
+        while(auto frame = reader.read()) targetDescriptors.push_back(frame->frameDescriptor);
 
     for (auto v2 : db.listVideos())
     {
         std::cout << "Calculating match for " << v2 << std::endl;
-        std::vector<cv::Mat> knownScenes;
+        std::vector<cv::Mat> knownDescriptors;
         auto v = db.loadVideo(v2);
 
         if constexpr(std::is_same_v<value_type, SerializableScene>) {
             auto scenes = v->getScenes();
-            while(auto scene = scenes->read()) knownScenes.push_back(scene->frameBag);
+            while(auto scene = scenes->read()) knownDescriptors.push_back(scene->frameBag);
         } else if constexpr(std::is_same_v<value_type, Frame>) {
             auto frames = v->frames();
-            while(auto frame = frames->read()) knownScenes.push_back(frame->frameDescriptor);
+            while(auto frame = frames->read()) knownDescriptors.push_back(frame->frameDescriptor);
         }
 
-        auto &&alignments = calculateAlignment(knownScenes, targetScenes, intcomp, 3, 2);
+        auto &&alignments = calculateAlignment(knownDescriptors, targetDescriptors, intcomp, 3, 2);
         // std::cout << targetScenes.size() << " " << knownScenes.size() << std::endl;
         if (alignments.size() > 0)
         {

--- a/src/matcher.cpp
+++ b/src/matcher.cpp
@@ -311,6 +311,7 @@ std::vector<MatchInfo> internal_findMatch(Reader&& reader, const FileDatabase &d
         std::vector<cv::Mat> knownDescriptors;
         std::vector<std::pair<unsigned int, unsigned int>> db_scenes;
         auto v = db.loadVideo(v2);
+        double frameRate = v->loadMetadata().frameRate;
 
         if constexpr(std::is_same_v<value_type, SerializableScene>) {
             auto scenes = v->getScenes();
@@ -333,13 +334,15 @@ std::vector<MatchInfo> internal_findMatch(Reader&& reader, const FileDatabase &d
                 if constexpr(std::is_same_v<value_type, SerializableScene>) {
                     match.push_back(MatchInfo{v->name,
                         static_cast<double>(a.score),
+                        frameRate,
                         query_scenes[a.startUnknown].first,
                         query_scenes[a.endUnknown - 1].second,
                         db_scenes[a.startKnown].first,
                         db_scenes[a.endKnown - 1].second});
                 } else if constexpr(std::is_same_v<value_type, Frame>)
                     match.push_back(MatchInfo{v->name, 
-                        static_cast<double>(a.score), 
+                        static_cast<double>(a.score),
+                        frameRate, 
                         a.startUnknown, 
                         a.endUnknown, 
                         a.startKnown, 

--- a/src/matcher.cpp
+++ b/src/matcher.cpp
@@ -26,12 +26,11 @@ std::vector<std::pair<unsigned int, unsigned int>> thresholdScenes(const std::ve
 std::vector<std::pair<unsigned int, unsigned int>> hierarchicalScenes(const std::vector<double>& distances, int min_scene_length)
 {
     std::vector<bool> excluded(distances.size(), 0);
-    std::vector<std::pair<double, int>> sorted_distances;
+    std::vector<std::pair<double, int>> sorted_distances(distances.size());
 
-    for (int i = 0; i < distances.size(); i++)
-    {
-        sorted_distances.emplace_back(distances[i], i);
-    }
+    std::transform(distances.begin(), distances.end(), sorted_distances.begin(), [index = 0](double val) mutable {
+        return std::make_pair(val, index++);
+    });
 
     std::vector<int> retval;
     std::sort(sorted_distances.begin(), sorted_distances.end(), [](auto l, auto r) { return l.first > r.first; });
@@ -285,28 +284,40 @@ double boneheadedSimilarity(IVideo &v1, IVideo &v2, std::function<double(Frame, 
 }*/
 
 template<typename Reader>
-std::optional<MatchInfo> internal_findMatch(Reader&& reader, const FileDatabase &db)
+std::vector<MatchInfo> internal_findMatch(Reader&& reader, const FileDatabase &db)
 {
     typedef typename decltype(reader.read())::value_type value_type;
     auto intcomp = [](auto f1, auto f2) { return cosineSimilarity(f1, f2) > 0.8 ? 3 : -3; };
 
-    MatchInfo match{};
-    std::vector<cv::Mat> targetDescriptors;
+    std::vector<MatchInfo> match;
 
-    if constexpr(std::is_same_v<value_type, SerializableScene>)
-        while(auto scene = reader.read()) targetDescriptors.push_back(scene->frameBag);
+    // load query information into array
+    std::vector<cv::Mat> targetDescriptors;
+    std::vector<std::pair<unsigned int, unsigned int>> query_scenes;
+
+    if constexpr(std::is_same_v<value_type, SerializableScene>) {
+        while(auto scene = reader.read()) {
+            targetDescriptors.push_back(scene->frameBag);
+            query_scenes.emplace_back(scene->startIdx, scene->endIdx);
+        }
+    }
     else if constexpr(std::is_same_v<value_type, Frame>)
         while(auto frame = reader.read()) targetDescriptors.push_back(frame->frameDescriptor);
 
-    for (auto v2 : db.listVideos())
+    // calculate alignments for each video in database
+    for (const std::string& v2 : db.listVideos())
     {
         std::cout << "Calculating match for " << v2 << std::endl;
         std::vector<cv::Mat> knownDescriptors;
+        std::vector<std::pair<unsigned int, unsigned int>> db_scenes;
         auto v = db.loadVideo(v2);
 
         if constexpr(std::is_same_v<value_type, SerializableScene>) {
             auto scenes = v->getScenes();
-            while(auto scene = scenes->read()) knownDescriptors.push_back(scene->frameBag);
+            while(auto scene = scenes->read()) {
+                knownDescriptors.push_back(scene->frameBag);
+                db_scenes.emplace_back(scene->startIdx, scene->endIdx);
+            }
         } else if constexpr(std::is_same_v<value_type, Frame>) {
             auto frames = v->frames();
             while(auto frame = frames->read()) knownDescriptors.push_back(frame->frameDescriptor);
@@ -316,39 +327,46 @@ std::optional<MatchInfo> internal_findMatch(Reader&& reader, const FileDatabase 
         // std::cout << targetScenes.size() << " " << knownScenes.size() << std::endl;
         if (alignments.size() > 0)
         {
-            auto &a = alignments[0];
-            std::cout << "Score: " << a.score << std::endl;
-            if (a.score > match.matchConfidence)
+            std::cout << "Score: " << alignments[0].score << std::endl;
+            for (auto a: alignments)
             {
-                match = MatchInfo{static_cast<double>(a.score), a.startKnown, a.endKnown, v2, alignments};
+                if constexpr(std::is_same_v<value_type, SerializableScene>) {
+                    match.push_back(MatchInfo{v->name,
+                        static_cast<double>(a.score),
+                        query_scenes[a.startUnknown].first,
+                        query_scenes[a.endUnknown - 1].second,
+                        db_scenes[a.startKnown].first,
+                        db_scenes[a.endKnown - 1].second});
+                } else if constexpr(std::is_same_v<value_type, Frame>)
+                    match.push_back(MatchInfo{v->name, 
+                        static_cast<double>(a.score), 
+                        a.startUnknown, 
+                        a.endUnknown, 
+                        a.startKnown, 
+                        a.endKnown});
             }
         } else {
             std::cout << "Score: 0" << std::endl;
         }
     }
 
-    if (match.matchConfidence > 0.5)
-    {
-        return match;
-    }
+    std::sort(match.begin(), match.end(), [](const MatchInfo& a, const MatchInfo& b){
+        return a.confidence > b.confidence;
+    });
 
-    return std::nullopt;
+    return match;
 }
 
-std::optional<MatchInfo> findMatch(QueryVideo& video, const FileDatabase &db) {
+std::vector<MatchInfo> findMatch(QueryVideo& video, const FileDatabase &db) {
     return internal_findMatch(*video.getScenes(), db);
 }
 
-std::optional<MatchInfo> findMatch(QueryVideo&& video, const FileDatabase &db) {
+std::vector<MatchInfo> findMatch(QueryVideo&& video, const FileDatabase &db) {
     return internal_findMatch(*video.getScenes(), db);
 }
 
-std::optional<MatchInfo> findMatch(std::unique_ptr<ICursor<Frame>> frames, const FileDatabase &db) {
+std::vector<MatchInfo> findMatch(std::unique_ptr<ICursor<Frame>> frames, const FileDatabase &db) {
     return internal_findMatch(*frames, db);
-}
-
-std::optional<MatchInfo> findMatch(std::unique_ptr<ICursor<SerializableScene>> scenes, const FileDatabase &db) {
-    return internal_findMatch(*scenes, db);
 }
 
 double BOWComparator::operator()(Frame &f1, Frame &f2)

--- a/src/storage.cpp
+++ b/src/storage.cpp
@@ -31,7 +31,7 @@ std::string to_string(const fs::path &path)
 }
 
 template <typename Range>
-void writeSequential(ofstream &fs, const Range &range)
+void writeSequential(ostream &fs, const Range &range)
 {
     size_t length = range.size();
     fs.write((char *)&length, sizeof(length));
@@ -42,7 +42,7 @@ void writeSequential(ofstream &fs, const Range &range)
 }
 
 template <typename T>
-std::vector<T> readSequence(ifstream &fs)
+std::vector<T> readSequence(istream &fs)
 {
     size_t length = 0;
     fs.read((char *)&length, sizeof(length));
@@ -53,7 +53,7 @@ std::vector<T> readSequence(ifstream &fs)
     return items;
 }
 
-cv::Mat readMat(ifstream &fs)
+cv::Mat readMat(istream &fs)
 {
     int type = 0, dims = 0;
     fs.read((char *)&type, sizeof(type));     // type
@@ -80,7 +80,7 @@ cv::Mat readMat(ifstream &fs)
     }
 }
 
-void writeMat(const cv::Mat &mat, ofstream &fs)
+void writeMat(const cv::Mat &mat, ostream &fs)
 {
     int type = mat.type(), dims = mat.dims;
     fs.write((char *)&type, sizeof(int));     // type


### PR DESCRIPTION
I've flattened the return value of findMatch into an array, and findMatch now returns the frame numbers if queried with scenes. Added a frameRate tag to the metadata, which I then use to calculate the timestamp from the frame numbers returned from findMatch.